### PR TITLE
Require a code owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JordanNanos @samharshe @Prathmesh234


### PR DESCRIPTION
## Purpose

The repository needs named owners for all files. Branch protection requires one owner approval.

## What changed

- Add one repository-wide rule to `.github/CODEOWNERS`.
- Assign `@JordanNanos`, `@samharshe`, and `@Prathmesh234` as owners.
- Require one code owner approval.
- Remove the last-pusher approval rule.

## Effect

- Users: None.
- Operators: One listed owner must approve each pull request.
- Developers: GitHub requests reviews from the three listed owners.
- Data and compatibility: None.

## Technical terms

- `CODEOWNERS`: A GitHub file that assigns reviewers to repository paths.
- `code owner`: A person who reviews changes to assigned files.
- `branch protection`: GitHub rules that control changes to `master`.

## Validation

- `git diff --cached --check`: Pass.
- `gh api repos/SemiAnalysisAI/ClusterMAX/collaborators/<login>/permission`: Pass. Each owner has write or administrator access.
- `gh api repos/SemiAnalysisAI/ClusterMAX/branches/master/protection/required_pull_request_reviews`: Pass. Code owner review is required.
- Not run: Runtime tests do not apply to a reviewer assignment file.

## Merge plan

- Merge order: None. This PR can merge independently.
- Dependency: Branch protection on `master`.
- Release step: Merge this PR to activate the owner assignments.

## Design decisions for approval

- Approval required: No.
- Decision: Require one approval from the three named owners.
- Options: Assign users directly or assign an organization team.
- Recommendation: Assign the three users directly as requested.
- Approver: Jordan Nanos.

## Risk and recovery

- Risk: An unavailable owner can delay a pull request.
- Safeguard: Any one of the three owners can approve.
- Rollback: Remove the rule and disable required code owner reviews.

## Excluded work

- Path-specific ownership rules.
- Organization team ownership.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change (reviewer assignment); no application code, data, or runtime behavior.
> 
> **Overview**
> Adds **`.github/CODEOWNERS`** with a single wildcard (`*`) rule so **every path** in the repo is owned by `@JordanNanos`, `@samharshe`, and `@Prathmesh234`.
> 
> When branch protection requires code owner reviews, GitHub will route PRs to those three accounts and **one of them must approve** before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7953d67d023b0319da6ae6bc2ca29c891917d244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->