### PR TITLE
Publish stable and nightly package channels

### DIFF
--- a/.github/workflows/python-nightly.yml
+++ b/.github/workflows/python-nightly.yml
@@ -1,19 +1,28 @@
-name: python-nightly
+name: python-publish
 
 on:
   schedule:
     - cron: '17 8 * * *'
   workflow_dispatch:
+    inputs:
+      channel:
+        description: Package channel to publish
+        required: true
+        default: nightly
+        type: choice
+        options:
+          - nightly
+          - stable
 
 concurrency:
-  group: python-nightly-0.2.1
+  group: python-publish-${{ inputs.channel || 'nightly' }}
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 env:
-  RELEASE_VERSION: 0.2.1
+  NIGHTLY_VERSION: 0.3.0
 
 jobs:
   build:
@@ -30,24 +39,43 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Set the nightly version
+      - name: Select the publication version
         id: version
+        env:
+          DISPATCH_CHANNEL: ${{ inputs.channel }}
         run: |
           commit="$(git rev-parse --short=12 HEAD)"
-          date_utc="$(date -u +%Y%m%d)"
-          version="$(python .github/scripts/nightly_version.py \
-            --release-version "$RELEASE_VERSION" \
-            --date "$date_utc" \
-            --run-number "$GITHUB_RUN_NUMBER")"
+          source_version="$(python -c 'import cmax; print(cmax.__version__)')"
+          channel="${DISPATCH_CHANNEL:-nightly}"
+          case "$channel" in
+            stable)
+              version="$source_version"
+              ;;
+            nightly)
+              date_utc="$(date -u +%Y%m%d)"
+              version="$(python .github/scripts/nightly_version.py \
+                --release-version "$NIGHTLY_VERSION" \
+                --date "$date_utc" \
+                --run-number "$GITHUB_RUN_NUMBER")"
+              ;;
+            *)
+              echo "Unknown publication channel: $channel" >&2
+              exit 1
+              ;;
+          esac
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
           echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "source_version=$source_version" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "### ClusterMAX nightly" >> "$GITHUB_STEP_SUMMARY"
+          echo "### ClusterMAX publication" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Channel: \`$channel\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Version: \`$version\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Commit: \`$commit\`" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Build the nightly distributions
+      - name: Build the distributions
         env:
           CLUSTERMAX_BUILD_VERSION: ${{ steps.version.outputs.version }}
+          SOURCE_VERSION: ${{ steps.version.outputs.source_version }}
         run: |
           python -m pip install \
             --require-hashes \
@@ -57,18 +85,18 @@ jobs:
           python -m build --no-isolation
           python -m twine check dist/*
           check-wheel-contents dist/clustermax-*.whl
-          test "$(python -c 'import cmax; print(cmax.__version__)')" = "0.2.1"
+          test "$(python -c 'import cmax; print(cmax.__version__)')" = "$SOURCE_VERSION"
 
-      - name: Verify the nightly wheel
+      - name: Verify the wheel
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          python -m venv /tmp/clustermax-nightly
-          /tmp/clustermax-nightly/bin/pip install dist/clustermax-*.whl
+          python -m venv /tmp/clustermax-publication
+          /tmp/clustermax-publication/bin/pip install dist/clustermax-*.whl
           cd /tmp
-          test "$(/tmp/clustermax-nightly/bin/cmax --version)" = "cmax ${EXPECTED_VERSION}"
-          /tmp/clustermax-nightly/bin/cmax audit --show
-          /tmp/clustermax-nightly/bin/cmax audit security --show
+          test "$(/tmp/clustermax-publication/bin/cmax --version)" = "cmax ${EXPECTED_VERSION}"
+          /tmp/clustermax-publication/bin/cmax audit --show
+          /tmp/clustermax-publication/bin/cmax audit security --show
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ cmax audit -h
 cmax audit security -h
 ```
 
-Nightly releases use the `0.2.1.devYYYYMMDDNN` format until the next major release, 3.0.
+Nightly releases use the `0.3.0.devYYYYMMDDNN` format until the stable 0.3.0
+release. This version is newer than stable 0.2.1 when `--pre` is enabled.
 
 ## Public documentation
 

--- a/tests/audit/test_nightly_version.py
+++ b/tests/audit/test_nightly_version.py
@@ -2,6 +2,8 @@ import importlib.util
 from pathlib import Path
 import unittest
 
+from packaging.version import Version
+
 
 SCRIPT_PATH = Path(__file__).parents[2] / ".github" / "scripts" / "nightly_version.py"
 SPEC = importlib.util.spec_from_file_location("nightly_version", SCRIPT_PATH)
@@ -14,15 +16,20 @@ SPEC.loader.exec_module(NIGHTLY_VERSION)
 class NightlyVersionTests(unittest.TestCase):
     def test_formats_the_first_daily_sequence_with_two_digits(self) -> None:
         self.assertEqual(
-            NIGHTLY_VERSION.nightly_version("0.2.1", "20260826", 1),
-            "0.2.1.dev2026082601",
+            NIGHTLY_VERSION.nightly_version("0.3.0", "20260826", 1),
+            "0.3.0.dev2026082601",
         )
 
     def test_keeps_a_run_number_longer_than_two_digits(self) -> None:
         self.assertEqual(
-            NIGHTLY_VERSION.nightly_version("0.2.1", "20260826", 123),
-            "0.2.1.dev20260826123",
+            NIGHTLY_VERSION.nightly_version("0.3.0", "20260826", 123),
+            "0.3.0.dev20260826123",
         )
+
+    def test_next_release_nightly_is_newer_than_current_stable(self) -> None:
+        nightly = NIGHTLY_VERSION.nightly_version("0.3.0", "20260826", 1)
+
+        self.assertGreater(Version(nightly), Version("0.2.1"))
 
     def test_rejects_an_invalid_release_version(self) -> None:
         with self.assertRaisesRegex(ValueError, "X.Y.Z"):
@@ -30,11 +37,11 @@ class NightlyVersionTests(unittest.TestCase):
 
     def test_rejects_an_invalid_calendar_date(self) -> None:
         with self.assertRaisesRegex(ValueError, "valid UTC calendar date"):
-            NIGHTLY_VERSION.nightly_version("0.2.1", "20260230", 1)
+            NIGHTLY_VERSION.nightly_version("0.3.0", "20260230", 1)
 
     def test_rejects_a_nonpositive_run_number(self) -> None:
         with self.assertRaisesRegex(ValueError, "positive integer"):
-            NIGHTLY_VERSION.nightly_version("0.2.1", "20260826", 0)
+            NIGHTLY_VERSION.nightly_version("0.3.0", "20260826", 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_nightly_version.py
+++ b/tests/test_nightly_version.py
@@ -5,7 +5,7 @@ import unittest
 from packaging.version import Version
 
 
-SCRIPT_PATH = Path(__file__).parents[2] / ".github" / "scripts" / "nightly_version.py"
+SCRIPT_PATH = Path(__file__).parents[1] / ".github" / "scripts" / "nightly_version.py"
 SPEC = importlib.util.spec_from_file_location("nightly_version", SCRIPT_PATH)
 assert SPEC is not None
 assert SPEC.loader is not None


### PR DESCRIPTION
## Purpose

Publish stable and nightly ClusterMAX packages from one trusted GitHub Actions workflow.

The current workflow can publish development builds only. A stable 0.2.1 package is required for default pip installation.

## What changed

- The publication workflow accepts stable and nightly channels.
- The stable channel uses the version in the source package.
- The nightly channel uses the 0.3.0.devYYYYMMDDNN format.
- The README explains the stable and nightly installation behavior.
- The version test proves that the nightly version is newer than stable 0.2.1.

## Effect

- Users: Default installation selects 0.2.1. Installation with --pre selects the newest 0.3.0 development build.
- Operators: A workflow dispatch can select stable or nightly publication.
- Developers: The scheduled workflow continues to select the nightly channel.
- Data and compatibility: Published package data does not change. Python 3.10 or later remains required.

## Technical terms

- `PyPI`: The Python Package Index that hosts installable Python packages.
- `pip`: The Python package installer.
- `--pre`: A pip option that permits prerelease versions.
- `development build`: A prerelease package created from code before the stable 0.3.0 release.
- `GitHub Actions`: The GitHub automation service that builds and publishes the package.

## Validation

- `uv run --isolated --with pytest --with packaging python -m pytest -q tests/test_nightly_version.py`: Pass. Six tests passed.
- `uv run --isolated --with pytest --with pyyaml --with prompt-toolkit python -m pytest -q`: Pass. 1,306 tests and 835 subtests passed.
- Local wheel resolver test: Pass. Default selected 0.2.1 and --pre selected 0.3.0.dev2026082801.
- `git diff --check`: Pass.

## Merge plan

- Merge order: None. This PR can merge independently.
- Dependency: The PyPI trusted publisher must permit `.github/workflows/python-nightly.yml` in `SemiAnalysisAI/ClusterMAX` with the `pypi` environment. This dependency is complete.
- Release step: Dispatch the stable channel from master. Approve publication. Then dispatch and approve the nightly channel.

## Design decisions for approval

- Approval required: Yes.
- Decision: Use 0.3.0 development versions for nightly packages after stable 0.2.1.
- Options: Use 0.2.2 development versions or 0.3.0 development versions.
- Recommendation: Use 0.3.0 development versions because this is the next planned stable release.
- Approver: JordanNanos approved the 0.3.0 development version before this PR.

## Risk and recovery

- Risk: An incorrect channel can publish an unwanted permanent version to PyPI.
- Safeguard: The stable channel uses the source version. The protected environment requires publication approval.
- Rollback: Revert the workflow change. Yank an incorrect PyPI release if publication occurs.

## Excluded work

- This PR does not publish a package before merge.
- This PR does not change the source package version from 0.2.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong channel or version logic can publish an unintended immutable PyPI release; safeguards are channel-specific versioning and the protected `pypi` environment.
> 
> **Overview**
> Renames the GitHub Actions workflow to **`python-publish`** and adds a **`workflow_dispatch` channel** (`stable` or `nightly`, default nightly). Scheduled runs still publish nightlies; operators can manually publish **stable** from `master`.
> 
> **Version selection** no longer hardcodes `0.2.1` for every build. **Stable** uses `cmax.__version__` from the repo (still `0.2.1` in this PR). **Nightly** builds use `0.3.0.devYYYYMMDDNN` via `NIGHTLY_VERSION: 0.3.0` and the existing nightly script. Concurrency groups are per channel; build checks assert the **source tree** version while the **wheel/CLI** report the publication version.
> 
> **README** documents the new nightly prefix and that `--pre` picks a prerelease newer than stable `0.2.1`. **Tests** fix the script path, expect `0.3.0` in nightly fixtures, and add a check that the nightly string sorts above `0.2.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd345d337d293f502fda4e57efba5e1af5ebf609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->