### PR TITLE
Separate stable and nightly publication gates

### DIFF
--- a/.github/workflows/python-nightly.yml
+++ b/.github/workflows/python-nightly.yml
@@ -28,6 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
+      channel: ${{ steps.version.outputs.channel }}
       version: ${{ steps.version.outputs.version }}
       commit: ${{ steps.version.outputs.commit }}
     steps:
@@ -110,7 +111,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: ${{ needs.build.outputs.channel == 'nightly' && 'pypi-nightly' || 'pypi' }}
       url: https://pypi.org/project/clustermax/
     permissions:
       id-token: write


### PR DESCRIPTION
## Purpose

Publish scheduled nightly packages without a manual deployment approval.

Stable releases must continue to require approval from a maintainer.

## What changed

- The build job exports its selected publication channel.
- The publish job selects `pypi-nightly` for nightly packages.
- The publish job keeps the protected `pypi` environment for stable packages.

## Effect

- Users: Nightly packages can arrive on the daily schedule without delay.
- Operators: Stable releases continue to require manual approval.
- Developers: Manual and scheduled nightly runs use the automatic environment.
- Data and compatibility: Package contents and version formats do not change.

## Technical terms

- `PyPI`: The Python Package Index that hosts installable Python packages.
- `GitHub Actions`: The GitHub automation service that builds and publishes the package.
- `environment`: A GitHub deployment control that can require approval or restrict branches.
- `trusted publisher`: A PyPI identity rule that permits one GitHub Actions workflow to publish without a stored token.

## Validation

- `uv run --isolated --with pyyaml python -c ...`: Pass. The workflow exports and uses the channel expression.
- `git diff --check`: Pass.
- Runtime tests: Not run. This change only selects a GitHub deployment environment.

## Merge plan

- Merge order: None. This PR can merge independently.
- Dependency: The `pypi-nightly` trusted publisher exists in the ClusterMAX PyPI project.
- Release step: Merge the PR. Dispatch one nightly run and confirm publication without approval.

## Design decisions for approval

- Approval required: Yes.
- Decision: Use separate environments for stable and nightly publication.
- Options: Remove approval from the shared environment or use a separate automatic nightly environment.
- Recommendation: Use a separate environment so stable releases keep manual approval.
- Approver: JordanNanos approved this work before the PR.

## Risk and recovery

- Risk: An incorrect environment name prevents nightly publication.
- Safeguard: The PyPI trusted publisher uses the same workflow and exact environment name.
- Rollback: Revert this PR. Nightly publication then returns to the protected stable environment.

## Excluded work

- This PR does not remove stable release approval.
- This PR does not change package files or package versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured environment names or trusted publishers could block nightly uploads or weaken stable-release protections; recovery is reverting the workflow change.
> 
> **Overview**
> **Nightly PyPI publishes can skip manual deployment approval** while stable releases still use the protected `pypi` environment.
> 
> The **build** job now exposes the selected publication **channel** as a job output (from the existing version step). The **publish** job picks the GitHub **environment** dynamically: `pypi-nightly` when the channel is `nightly`, otherwise `pypi`. Package build logic and version formats are unchanged—only which approval gate applies at publish time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a807690c9412f85562d4654bf5124251bb548be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->