### PR TITLE
Update README with enhanced `cmax` CLI details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # ClusterMAX
 
-This repo is for `cmax`, a CLI tool that we use to audit GPU clusters and standalone machines during research for ClusterMAX. The initial release supports our recent article on neocloud security that precedes ClusterMAX 3.0.
+This repo is for `cmax`, a CLI tool that we use to audit GPU clusters and standalone machines during research for ClusterMAX. 
 
-Version 0.2.1 of the `cmax` CLI provides these functional commands:
+The initial release is a small subset of our full test suite. It supports our recent article on neocloud security that precedes ClusterMAX 3.0.
+
+This version of the `cmax` CLI provides the following commands:
 
 | Command | Function |
 |---|---|
 | `cmax audit security` | This command runs a focused, read-only security audit. |
-| `cmax audit` | This command runs the complete cluster audit. |
-| `cmax audit review` | This command reviews a saved audit without new checks. |
+| `cmax audit` | This command runs a full cluster audit covering more than just security. |
+| `cmax audit review` | This command reviews a saved audit output without running new checks. |
 
 ## Install ClusterMAX
 


### PR DESCRIPTION
Clarified the description of the `cmax` CLI tool and updated command functionalities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no code or behavior changes.
> 
> **Overview**
> **README intro** is reorganized: the opening line no longer ties the tool description to a specific release, and a new paragraph states the public CLI is a **small subset** of the full test suite and supports the neocloud security article ahead of ClusterMAX 3.0.
> 
> The commands section heading drops the **0.2.1** version label in favor of “This version of the `cmax` CLI,” and the table copy is tightened—**`cmax audit`** is described as a full audit beyond security only, and **`cmax audit review`** as reviewing saved **audit output** without re-running checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edcc75e318c61871a84e0e15a149356c33be499b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->